### PR TITLE
Fix repeat readings from DHT11

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ module.exports = function(pin, type) {
 			tempLow = 0;
 			checksum = 0;
 
+			// Set the pin high, particularly for when this is the second or later reading.
+			gpio.digitalWrite(1);
+			lastHighTick = pigpio.getTick();
+
 			// start reading input
 			gpio.mode(Gpio.INPUT);
 			gpio.enableAlert();

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = function(pin, type) {
 
 		// bits are only accumulated on the low level
 		if (level == 0) {
-			let diff = (tick >> 0) - (lastHighTick >> 0);
+			let diff = pigpio.tickDiff(lastHighTick, tick);
 
 			// Edge length determines if bit is 1 or 0.
 			let val = 0;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
-const Gpio = require('pigpio').Gpio;
+
+const pigpio = require('pigpio');
+const Gpio = pigpio.Gpio;
 const eventEmitter = require('events').EventEmitter;
 
 module.exports = function(pin, type) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,11 @@
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
     },
     "pigpio": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/pigpio/-/pigpio-0.6.4.tgz",
-      "integrity": "sha512-BEDRdEUJUAFZGZQ7PWd8ihnOe+Vdw/TdSjwI614WxF5bGwXSWODQntYR+WTU1mEbJhf44Y4rqdTLOqztNsncIQ==",
+      "version": "git://github.com/erikma/pigpio-1.git#943fee70f37a773ee48c28789a21d13a548bf153",
+      "from": "git://github.com/erikma/pigpio-1.git#dev/erikma/ticks",
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0"
+        "bindings": "^1.3.0",
+        "nan": "^2.11.1"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pigpio-dht",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pigpio-dht",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9,17 +9,20 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
       "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
-    },
     "pigpio": {
-      "version": "git://github.com/erikma/pigpio-1.git#943fee70f37a773ee48c28789a21d13a548bf153",
-      "from": "git://github.com/erikma/pigpio-1.git#dev/erikma/ticks",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pigpio/-/pigpio-1.2.0.tgz",
+      "integrity": "sha512-DGopuMdjmRguqydLZ3A16PYOiJWtl705aGF3a48Tnc6woLyts4Zj01FklJYgTqFMCZy4ZBHg49xe+W5yG5+jOw==",
       "requires": {
         "bindings": "^1.3.0",
         "nan": "^2.11.1"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.11.1",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+          "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pigpio-dht",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Dht22 control using node.js and pigpio.",
   "main": "index.js",
   "scripts": {
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/depuits/pigpio-dht#readme",
   "dependencies": {
-    "pigpio": "^0.6.4"
+    "pigpio": "^1.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/depuits/pigpio-dht#readme",
   "dependencies": {
-    "pigpio": "^1.1.4"
+    "pigpio": "^1.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pigpio-dht",
-  "version": "1.1.2",
+  "version": "1.1.1",
   "description": "Dht22 control using node.js and pigpio.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pigpio-dht",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Dht22 control using node.js and pigpio.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "keywords": [
     "DHT",
+    "DHT11",
     "DHT22",
+    "AM2302",
     "pigpio",
     "raspberry",
     "pi"


### PR DESCRIPTION
Update to pigpio version 1.2.0 containing new getTick() and tickDiff() functions, and use those functions to fix a problem with reading the sensor repeatedly. Ensure the DHT11 data pin is set high when still in output mode before switching to input mode, to ensure the sensor can see the difference in voltage from reading to reading, and track the baseline start tick value from that voltage change.

This fix is working in a DHT11 based sensor project that reads the sensor once per minute for multiple days in a row successfully.